### PR TITLE
fix: Run "dotnet restore"

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -79,7 +79,7 @@ if (args.Length > 0)
                              npm ci
 
                              # Generate vidyano libman files
-                             dotnet restore
+                             dotnet build
                                  
                              # compile Sass → CSS
                              find wwwroot -type f -name "*.scss" -print -execdir sh -c 'sass "{}:${1%.scss}.css"' _ {} \;

--- a/Program.cs
+++ b/Program.cs
@@ -78,6 +78,9 @@ if (args.Length > 0)
                              # install dependencies
                              npm ci
 
+                             # Generate vidyano libman files
+                             dotnet restore
+                                 
                              # compile Sass → CSS
                              find wwwroot -type f -name "*.scss" -print -execdir sh -c 'sass "{}:${1%.scss}.css"' _ {} \;
 


### PR DESCRIPTION
# Description
- Blocked by https://github.com/stevehansen/vidyano-frontend-builder/pull/7
- We need to run `dotnet restore` to have the vidyano libman files on the drive

# Screenshots
![image](https://github.com/user-attachments/assets/80d44334-f481-469a-b857-77a96c992f51)


# Linked issues
- Closes #2 