### PR TITLE
feat: Add command to cleanout the CWD (#4)

### DIFF
--- a/Dev.csproj
+++ b/Dev.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>True</PackAsTool>
     <ToolCommandName>dev</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Description>A development tool to simplify common tasks in .NET projects</Description>
     <Authors>Hansen Consultancy</Authors>
     <PackageIcon>logo-128x128.png</PackageIcon>

--- a/Program.cs
+++ b/Program.cs
@@ -162,7 +162,7 @@ if (args.Length > 0)
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Failed to delete {folderPath}: {ex.Message}");
+                AnsiConsole.WriteException(ex);
             }
         }
         return;

--- a/Program.cs
+++ b/Program.cs
@@ -41,6 +41,7 @@ if (args.Length > 0)
         table.AddRow("bump-commit (vc) [major|minor|patch|revision]".EscapeMarkup(), "Bumps the version and commits/tag the change in the current solution or project. Defaults to minor.");
         table.AddRow("build (b)", "Builds the current solution or project in Release mode.");
         table.AddRow("frontend (f)", "Runs the Vidyano frontend builder in the current directory.");
+        table.AddRow("clean", "Clean the current folder by removing [yellow]bin[/], [yellow]obj[/], [yellow]tmp-build[/], [yellow]bin-windows[/], [yellow]bin-linux[/], [yellow]obj-windows[/], [yellow]obj-linux[/] folders. Use this command if you experience build issues.");
         table.AddRow("help (h)", "Displays this help message.");
 
         AnsiConsole.Write(table);
@@ -136,6 +137,23 @@ if (args.Length > 0)
             Process.Start("cmd.exe", $"/c {dockerCommand}").WaitForExit();
         else
             Process.Start("bash", $"-c \"{dockerCommand}\"").WaitForExit();
+        return;
+    }
+
+    if (command is "clean")
+    {
+        AnsiConsole.MarkupLine("[green]Cleaning current directory...[/]");
+        // Clean the current directory by removing bin, obj, tmp-build, bin-windows, bin-linux, obj-windows and obj-linux folders
+        var foldersToDelete = new[] { "bin", "obj", "tmp-build", "bin-windows", "bin-linux", "obj-windows", "obj-linux" };
+        foreach (var folder in foldersToDelete)
+        {
+            var folderPath = Path.Combine(path, folder);
+            if (Directory.Exists(folderPath))
+            {
+                AnsiConsole.MarkupLine($"[red]Deleting[/] {folderPath} [red]folder...[/]");
+                Directory.Delete(folderPath, true);
+            }
+        }
         return;
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -143,15 +143,26 @@ if (args.Length > 0)
     if (command is "clean")
     {
         AnsiConsole.MarkupLine("[green]Cleaning current directory...[/]");
+
         // Clean the current directory by removing bin, obj, tmp-build, bin-windows, bin-linux, obj-windows and obj-linux folders
         var foldersToDelete = new[] { "bin", "obj", "tmp-build", "bin-windows", "bin-linux", "obj-windows", "obj-linux" };
-        foreach (var folder in foldersToDelete)
+        var allDirectories = Directory.EnumerateDirectories(path, "*", SearchOption.AllDirectories)
+            .Where(dir => !dir.Contains("node_modules", StringComparison.OrdinalIgnoreCase))
+            .Where(dir => foldersToDelete.Contains(Path.GetFileName(dir), StringComparer.OrdinalIgnoreCase));
+
+        foreach (var folderPath in allDirectories)
         {
-            var folderPath = Path.Combine(path, folder);
-            if (Directory.Exists(folderPath))
+            try
             {
-                AnsiConsole.MarkupLine($"[red]Deleting[/] {folderPath} [red]folder...[/]");
-                Directory.Delete(folderPath, true);
+                if (Directory.Exists(folderPath))
+                {
+                    AnsiConsole.MarkupLine($"[red]Deleting[/] {folderPath} [red]folder...[/]");
+                    Directory.Delete(folderPath, recursive: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to delete {folderPath}: {ex.Message}");
             }
         }
         return;

--- a/Program.cs
+++ b/Program.cs
@@ -162,7 +162,7 @@ if (args.Length > 0)
             }
             catch (Exception ex)
             {
-                AnsiConsole.WriteException(ex);
+                AnsiConsole.WriteException(ex, ExceptionFormats.ShowLinks);
             }
         }
         return;


### PR DESCRIPTION
Past few years, I made several changes in the way .NET build files are produced. First we had `obj-windows`/`obj-linux` then I changed the output path to `tmp-build/...`. Then I moved these msbuild tags to the `Directory.Build.targets`.

On each change, for repositories that were already present on devs devices, the dev had to cleanout all these folders, restart Visual Studio before they could properly build the project again.

This PR adds a command `dev clean` that finds all of these folders in the current-working-directory and attempts to delete them in a one-liner. We have to be careful though that we don't remove `bin` folders inside the `node_modules`.