### PR TITLE
refactor: collapse the four-way command-set duplication into a single CommandCatalog (#24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Commands can be combined using the `+` operator to execute them sequentially (e.
 
 ## Ubiquitous Language
 
-`UBIQUITOUS_LANGUAGE.md` (repo root) is the canonical domain glossary — the agreed vocabulary for the CLI's run/command, workspace/versioning, trust, and frontend subdomains. Use these terms in code, comments, help text, and JSON envelope fields; consult its "Flagged ambiguities" before naming new concepts — notably **Build** (compile command vs. SemVer 3rd component vs. build metadata), **Patch/Revision** (CLI bump parts) vs. their `Build`/`Fix` SemVer fields, and **Target** (`BuildTarget` what-to-compile vs. `BumpTarget` what-to-version). Update it when introducing or renaming a domain concept.
+`UBIQUITOUS_LANGUAGE.md` (repo root) is the canonical domain glossary — the agreed vocabulary for the CLI's run/command, workspace/versioning, trust, and frontend subdomains. Use these terms in code, comments, help text, and JSON envelope fields; consult its "Flagged ambiguities" before naming new concepts — notably **Build** (compile command vs. SemVer 3rd component vs. build metadata), **Patch/Revision** (CLI bump parts) vs. their `Build`/`Fix` SemVer fields, **Target** (`BuildTarget` what-to-compile vs. `BumpTarget` what-to-version), and **Built-in** (the command verb vs. the `BuiltinCommand` record vs. the `BuiltIn` config field). Update it when introducing or renaming a domain concept.
 
 ## Security & STRIDE Threat Model
 

--- a/CommandCatalog.cs
+++ b/CommandCatalog.cs
@@ -1,27 +1,55 @@
-// Single source of truth for the CLI's command vocabulary: the alias→builtin
-// mapping shared by command resolution and by the unknown-command suggestion
-// logic, plus a pure nearest-match Suggest. Kept pure (no I/O) and exhaustively
-// testable, mirroring TrustGate.Decide's style.
+// Single source of truth for the CLI's command vocabulary: the rich Builtins
+// registry (name, aliases, description, needs-workspace, default-ness, arg-syntax)
+// from which the alias map, command resolution, unknown-command suggestion, and the
+// render-ready help model are all derived. Kept pure (no I/O) and exhaustively
+// testable, mirroring TrustGate.Decide's style. Owns the builtin <-> config merge
+// policy (the "is there a commands.json?" fork) so no consumer re-encodes it.
+
+using System.Runtime.InteropServices;
 
 namespace Dev;
 
+// One builtin command's canonical facts. NeedsWorkspace was previously implicit in
+// the dispatch switch's ordering relative to the workspace-null guard; it is now data.
+internal sealed record BuiltinCommand(
+    string Name, string[] Aliases, string Description,
+    bool NeedsWorkspace, bool IsDefault, string? ArgSyntax);
+
+// One render-ready help row. Both the --json payload and the human table consume
+// these and never re-derive names/aliases/descriptions or repeat the config merge.
+internal sealed record HelpRow(
+    string Name, string[] Aliases, string Description,
+    bool? IsDefault,    // NULL only for the synthetic help row — the discriminator the JSON mapper keys off
+    string Source,      // "builtin" | "config"
+    string? BuiltIn, string? ArgSyntax);
+
 internal static class CommandCatalog
 {
-    public static IReadOnlyDictionary<string, string> Aliases { get; } = new Dictionary<string, string>
+    // THE registry — a static readonly LITERAL, not a table populated at runtime by a
+    // Bind()-style call from Program startup. Order is the canonical help/suggest order;
+    // help last. CommandCatalogResolveTests.AllAliases() enumerates the derived Aliases
+    // at test-collection time: a literal is filled by static initialization on first
+    // access (so it's ready), whereas a Bind()-from-startup table would still be empty
+    // then (startup never ran), silently yielding zero theory cases.
+    public static IReadOnlyList<BuiltinCommand> Builtins { get; } = new[]
     {
-        ["b"] = "build",
-        ["c"] = "clean",
-        ["h"] = "help",
-        ["?"] = "help",
-        ["f"] = "frontend",
-        ["v"] = "bump",
-        ["vc"] = "bump-commit",
+        new BuiltinCommand("launch", [], "Launches the current solution in your default IDE or project in Visual Studio Code.", NeedsWorkspace: true, IsDefault: true, ArgSyntax: null),
+        new BuiltinCommand("bump", ["v"], "Bumps the version of all projects in the current solution or the current project. Defaults to minor.", NeedsWorkspace: true, IsDefault: false, ArgSyntax: "[major|minor|patch|revision]"),
+        new BuiltinCommand("bump-commit", ["vc"], "Bumps the version and commits/tag the change in the current solution or project. Defaults to minor.", NeedsWorkspace: true, IsDefault: false, ArgSyntax: "[major|minor|patch|revision]"),
+        new BuiltinCommand("build", ["b"], "Builds the current solution or project in Release mode.", NeedsWorkspace: true, IsDefault: false, ArgSyntax: null),
+        new BuiltinCommand("frontend", ["f"], "Runs the Vidyano frontend builder in the current directory.", NeedsWorkspace: false, IsDefault: false, ArgSyntax: null),
+        new BuiltinCommand("clean", ["c"], "Clean the current folder by removing bin, obj, tmp-build, bin-windows, bin-linux, obj-windows, obj-linux folders.", NeedsWorkspace: false, IsDefault: false, ArgSyntax: null),
+        new BuiltinCommand("help", ["h", "?"], "Displays this help message.", NeedsWorkspace: false, IsDefault: false, ArgSyntax: null),
     };
 
-    public static IReadOnlyList<string> Builtins { get; } = new[]
-    {
-        "launch", "bump", "bump-commit", "build", "frontend", "clean", "help",
-    };
+    // Derived once from Builtins — replaces the hand-maintained inverted literals.
+    public static IReadOnlyDictionary<string, string> Aliases { get; } =
+        Builtins.SelectMany(c => c.Aliases.Select(a => (a, c.Name))).ToDictionary(t => t.a, t => t.Name);
+
+    // Case-sensitive (Ordinal): dispatch resolves to a canonical builtin name and
+    // must not treat "BUILD" as "build".
+    public static BuiltinCommand? Find(string name) =>
+        Builtins.FirstOrDefault(c => string.Equals(c.Name, name, StringComparison.Ordinal));
 
     public static (string Command, string? Alias) Resolve(string input) =>
         Aliases.TryGetValue(input, out var command) ? (command, input) : (input, null);
@@ -61,6 +89,60 @@ internal static class CommandCatalog
     // Returns plain text; the caller is responsible for any renderer escaping.
     public static string DescribeSuggestion(string suggestion) =>
         Aliases.TryGetValue(suggestion, out var full) ? $"'{suggestion}' ({full})" : $"'{suggestion}'";
+
+    // Candidate set for an unknown-command "did you mean":
+    //   no config -> builtin names + alias keys (today's behavior)
+    //   config    -> config names only (undeclared builtins are "unknown")
+    public static IEnumerable<string> SuggestionCandidates(IReadOnlyList<CommandsConfigEntry>? config) =>
+        config is null ? Builtins.Select(c => c.Name).Concat(Aliases.Keys)
+                       : config.Select(c => c.Name);
+
+    // The complete, ordered, render-ready help model for the active config. Both
+    // renderers iterate this and nothing else. Centralizes the config fork, the
+    // OS-specific custom-command description fallback, alias inversion, the help/h
+    // skip filter, and help-row synthesis.
+    public static IReadOnlyList<HelpRow> HelpModel(IReadOnlyList<CommandsConfigEntry>? config)
+    {
+        var help = Find("help")!;
+        var helpRow = new HelpRow(help.Name, help.Aliases, help.Description,
+            IsDefault: null, Source: "builtin", BuiltIn: null, ArgSyntax: null);
+
+        if (config is null)
+        {
+            var rows = new List<HelpRow>();
+            foreach (var c in Builtins)
+            {
+                if (string.Equals(c.Name, "help", StringComparison.Ordinal)) continue;
+                rows.Add(new HelpRow(c.Name, c.Aliases, c.Description,
+                    IsDefault: c.IsDefault, Source: "builtin", BuiltIn: null, ArgSyntax: c.ArgSyntax));
+            }
+            rows.Add(helpRow);
+            return rows;
+        }
+
+        var configRows = new List<HelpRow>();
+        foreach (var c in config)
+        {
+            if (c.Name is "help" or "h") continue;
+            if (!string.IsNullOrEmpty(c.BuiltIn))
+            {
+                var backing = Find(c.BuiltIn);
+                configRows.Add(new HelpRow(c.Name, backing?.Aliases ?? [],
+                    backing?.Description ?? c.BuiltIn,
+                    IsDefault: c.Default, Source: "builtin", BuiltIn: c.BuiltIn, ArgSyntax: null));
+            }
+            else
+            {
+                var desc = c.Description
+                    ?? (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? c.Windows : c.NonWindows)
+                    ?? "";
+                configRows.Add(new HelpRow(c.Name, [], desc,
+                    IsDefault: c.Default, Source: "config", BuiltIn: null, ArgSyntax: null));
+            }
+        }
+        configRows.Add(helpRow);
+        return configRows;
+    }
 
     private static int Levenshtein(string a, string b)
     {

--- a/Program.cs
+++ b/Program.cs
@@ -128,16 +128,7 @@ static int Finish(Envelope envelope, RunContext ctx, Stopwatch watch)
 {
     envelope.DurationMs = watch.ElapsedMilliseconds;
     if (ctx.JsonMode)
-    {
-        var opts = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            WriteIndented = true,
-            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        };
-        Console.Out.WriteLine(JsonSerializer.Serialize(envelope, opts));
-    }
+        Console.Out.WriteLine(JsonSerializer.Serialize(envelope, Program.JsonOptions));
     return envelope.ExitCode;
 }
 
@@ -153,12 +144,9 @@ static StepResult ExecuteCommand(
 
     try
     {
-        if (command is "help")
-        {
-            step.Data = BuildHelpData(configCommands);
-            if (!ctx.JsonMode) RenderHelpTable(configCommands);
-            return step;
-        }
+        // help short-circuits before the commands.json unknown-command rejection so
+        // `dev help` works regardless of whether commands.json declares it.
+        if (command is "help") return RunHelp(configCommands, step, ctx);
 
         if (configCommands is not null)
         {
@@ -176,7 +164,7 @@ static StepResult ExecuteCommand(
                 ctx.Log($"[red]Unknown command: {command}[/]");
                 // When a commands.json exists, builtins it doesn't declare are
                 // also "Unknown command", so suggest only config command names.
-                var suggestion = CommandCatalog.Suggest(command, configCommands.Select(c => c.Name));
+                var suggestion = CommandCatalog.Suggest(command, CommandCatalog.SuggestionCandidates(configCommands));
                 if (suggestion is not null)
                     ctx.Log($"[yellow]Did you mean {CommandCatalog.DescribeSuggestion(suggestion).EscapeMarkup()}?[/]");
                 step.Status = "failed";
@@ -186,10 +174,20 @@ static StepResult ExecuteCommand(
             }
         }
 
-        if (command is "frontend") return RunFrontend(path, step, ctx);
-        if (command is "clean") return RunClean(path, step, ctx);
+        var spec = CommandCatalog.Find(command);
+        if (spec is null)
+        {
+            ctx.Log($"[red]Unknown command: {command}[/]");
+            var suggestion = CommandCatalog.Suggest(command, CommandCatalog.SuggestionCandidates(configCommands));
+            if (suggestion is not null)
+                ctx.Log($"[yellow]Did you mean {CommandCatalog.DescribeSuggestion(suggestion).EscapeMarkup()}?[/]");
+            step.Status = "failed";
+            step.ExitCode = 3;
+            step.Error = new StepError { Code = "unknown_command", Message = $"Unknown command: {command}", Suggestion = suggestion };
+            return step;
+        }
 
-        if (workspace is null)
+        if (spec.NeedsWorkspace && workspace is null)
         {
             ctx.Log("[red]No .sln, .slnx or .csproj file found in the current directory or src/ folder.[/]");
             step.Status = "failed";
@@ -198,27 +196,30 @@ static StepResult ExecuteCommand(
             return step;
         }
 
-        switch (command)
+        // Dispatch on the canonical name (spec.Name), not the raw input.
+        return spec.Name switch
         {
-            case "bump": return RunBump(workspace, commandArgs, step, ctx);
-            case "bump-commit": return RunBumpCommit(workspace, commandArgs, step, ctx);
-            case "build": return RunBuild(workspace.BuildTarget, step, ctx);
-            case "launch": return RunLaunch(workspace, step, ctx);
-            default:
-                ctx.Log($"[red]Unknown command: {command}[/]");
-                var suggestion = CommandCatalog.Suggest(command, CommandCatalog.Builtins.Concat(CommandCatalog.Aliases.Keys));
-                if (suggestion is not null)
-                    ctx.Log($"[yellow]Did you mean {CommandCatalog.DescribeSuggestion(suggestion).EscapeMarkup()}?[/]");
-                step.Status = "failed";
-                step.ExitCode = 3;
-                step.Error = new StepError { Code = "unknown_command", Message = $"Unknown command: {command}", Suggestion = suggestion };
-                return step;
-        }
+            "launch" => RunLaunch(workspace!, step, ctx),
+            "bump" => RunBump(workspace!, commandArgs, step, ctx),
+            "bump-commit" => RunBumpCommit(workspace!, commandArgs, step, ctx),
+            "build" => RunBuild(workspace!.BuildTarget, step, ctx),
+            "frontend" => RunFrontend(path, step, ctx),
+            "clean" => RunClean(path, step, ctx),
+            "help" => RunHelp(configCommands, step, ctx), // reached only via a commands.json entry whose "builtIn" is "help"; the bare help command short-circuits above. Kept so the switch stays exhaustive over Builtins.
+            _ => throw new UnreachableException(),
+        };
     }
     finally
     {
         step.DurationMs = watch.ElapsedMilliseconds;
     }
+}
+
+static StepResult RunHelp(List<CommandsConfigEntry>? configCommands, StepResult step, RunContext ctx)
+{
+    step.Data = Program.BuildHelpData(configCommands);
+    if (!ctx.JsonMode) RenderHelpTable(configCommands);
+    return step;
 }
 
 static StepResult RunCustomCommand(CommandsConfigEntry cfg, Workspace? workspace, string path, StepResult step, RunContext ctx)
@@ -463,80 +464,6 @@ static string ReplaceVariables(string command, string? slnFile, string? csprojFi
         .Replace("{dir}", path);
 }
 
-static object BuildHelpData(List<CommandsConfigEntry>? configCommands)
-{
-    var aliases = new Dictionary<string, string[]>
-    {
-        ["build"] = new[] { "b" },
-        ["help"] = new[] { "h", "?" },
-        ["frontend"] = new[] { "f" },
-        ["bump"] = new[] { "v" },
-        ["bump-commit"] = new[] { "vc" },
-        ["clean"] = new[] { "c" },
-    };
-
-    var commands = new List<Dictionary<string, object?>>();
-    if (configCommands is not null)
-    {
-        foreach (var c in configCommands)
-        {
-            if (c.Name is "help" or "h") continue;
-            var desc = !string.IsNullOrEmpty(c.BuiltIn)
-                ? BuiltinDescription(c.BuiltIn)
-                : c.Description ?? (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? c.Windows : c.NonWindows) ?? "";
-            commands.Add(new Dictionary<string, object?>
-            {
-                ["name"] = c.Name,
-                ["aliases"] = !string.IsNullOrEmpty(c.BuiltIn) && aliases.TryGetValue(c.BuiltIn, out var al) ? al : Array.Empty<string>(),
-                ["description"] = desc,
-                ["default"] = c.Default,
-                ["source"] = !string.IsNullOrEmpty(c.BuiltIn) ? "builtin" : "config",
-                ["builtIn"] = c.BuiltIn,
-            });
-        }
-    }
-    else
-    {
-        foreach (var name in new[] { "launch", "bump", "bump-commit", "build", "frontend", "clean" })
-        {
-            commands.Add(new Dictionary<string, object?>
-            {
-                ["name"] = name,
-                ["aliases"] = aliases.TryGetValue(name, out var al) ? al : Array.Empty<string>(),
-                ["description"] = BuiltinDescription(name),
-                ["default"] = name == "launch",
-                ["source"] = "builtin",
-            });
-        }
-    }
-    commands.Add(new Dictionary<string, object?>
-    {
-        ["name"] = "help",
-        ["aliases"] = aliases["help"],
-        ["description"] = "Displays this help message.",
-        ["source"] = "builtin",
-    });
-
-    return new Dictionary<string, object?>
-    {
-        ["commands"] = commands,
-        ["chaining"] = new Dictionary<string, object?> { ["separator"] = "+", ["example"] = "dev b+f" },
-        ["placeholders"] = new[] { "{sln}", "{project}", "{dir}" },
-        ["globalFlags"] = new[] { "--json", "--yes" },
-    };
-}
-
-static string BuiltinDescription(string name) => name switch
-{
-    "launch" => "Launches the current solution in your default IDE or project in Visual Studio Code.",
-    "bump" => "Bumps the version of all projects in the current solution or the current project. Defaults to minor.",
-    "bump-commit" => "Bumps the version and commits/tag the change in the current solution or project. Defaults to minor.",
-    "build" => "Builds the current solution or project in Release mode.",
-    "frontend" => "Runs the Vidyano frontend builder in the current directory.",
-    "clean" => "Clean the current folder by removing bin, obj, tmp-build, bin-windows, bin-linux, obj-windows, obj-linux folders.",
-    _ => name,
-};
-
 static void RenderHelpTable(List<CommandsConfigEntry>? configCommands)
 {
     var table = new Table()
@@ -544,27 +471,16 @@ static void RenderHelpTable(List<CommandsConfigEntry>? configCommands)
         .AddColumn(new TableColumn("[green]Command[/]").LeftAligned())
         .AddColumn(new TableColumn("[blue]Description[/]").LeftAligned());
 
-    if (configCommands is not null)
+    foreach (var r in CommandCatalog.HelpModel(configCommands))
     {
-        foreach (var c in configCommands)
-        {
-            if (c.Name is "help" or "h") continue;
-            var desc = !string.IsNullOrEmpty(c.BuiltIn) ? BuiltinDescription(c.BuiltIn)
-                : c.Description ?? (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? c.Windows : c.NonWindows) ?? string.Empty;
-            table.AddRow($"{c.Name}{(c.Default ? " (default)" : string.Empty)}".EscapeMarkup(), desc.EscapeMarkup());
-        }
-    }
-    else
-    {
-        table.AddRow("launch (default)", BuiltinDescription("launch"));
-        table.AddRow("bump (v) [major|minor|patch|revision]".EscapeMarkup(), BuiltinDescription("bump"));
-        table.AddRow("bump-commit (vc) [major|minor|patch|revision]".EscapeMarkup(), BuiltinDescription("bump-commit"));
-        table.AddRow("build (b)", BuiltinDescription("build"));
-        table.AddRow("frontend (f)", BuiltinDescription("frontend"));
-        table.AddRow("clean (c)", BuiltinDescription("clean"));
+        // builtins enumeration + synthetic help row carry alias/arg hints; bare config rows don't.
+        var decorate = configCommands is null || r.IsDefault is null;
+        var alias = decorate && r.Aliases.Length > 0 ? $" ({string.Join(", ", r.Aliases)})" : "";
+        var def = r.IsDefault == true ? " (default)" : "";
+        var arg = decorate && r.ArgSyntax is not null ? " " + r.ArgSyntax : "";
+        table.AddRow($"{r.Name}{alias}{def}{arg}".EscapeMarkup(), r.Description.EscapeMarkup());
     }
 
-    table.AddRow("help (h)", "Displays this help message.");
     table.AddEmptyRow();
     table.AddRow("[dim]Combine commands with '+'[/]", "[dim]Example: dev b+f (build then frontend)[/]");
     table.AddRow("[dim]Global flags[/]", "[dim]--json (machine output)  --yes (auto-accept prompts)[/]");
@@ -577,6 +493,48 @@ partial class Program
     internal static IProcessRunner Runner { get; set; } = new RealProcessRunner();
     internal static IFrontendEnvironment FrontendEnv { get; set; } = new FrontendEnvironment();
     internal static IFrontendBuild FrontendBuilder { get; set; } = new FrontendBuild();
+
+    // Shared so the --json help golden test can serialize BuildHelpData with the
+    // exact options the tool emits with.
+    internal static JsonSerializerOptions JsonOptions { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    // Mirror of the dispatch arms in ExecuteCommand's switch. Kept in sync by hand;
+    // CommandCatalog<->dispatch drift is turned into a test failure by the exhaustiveness test.
+    internal static readonly IReadOnlySet<string> DispatchableCommands =
+        new HashSet<string>(StringComparer.Ordinal) { "launch", "bump", "bump-commit", "build", "frontend", "clean", "help" };
+
+    // The --json help payload. Maps CommandCatalog.HelpModel; dictionary keys are
+    // added conditionally because WhenWritingNull does NOT drop null *values* inside
+    // a Dictionary<string, object?>, only null properties on typed objects.
+    internal static object BuildHelpData(List<CommandsConfigEntry>? config)
+    {
+        var commands = CommandCatalog.HelpModel(config).Select(r =>
+        {
+            var d = new Dictionary<string, object?>
+            {
+                ["name"] = r.Name,
+                ["aliases"] = r.Aliases,
+                ["description"] = r.Description,
+            };
+            if (r.IsDefault is not null) d["default"] = r.IsDefault.Value;   // absent on help row
+            d["source"] = r.Source;
+            if (config is not null && r.IsDefault is not null) d["builtIn"] = r.BuiltIn;  // present (maybe null) for config rows only
+            return d;
+        }).ToList();
+        return new Dictionary<string, object?>
+        {
+            ["commands"] = commands,
+            ["chaining"] = new Dictionary<string, object?> { ["separator"] = "+", ["example"] = "dev b+f" },
+            ["placeholders"] = new[] { "{sln}", "{project}", "{dir}" },
+            ["globalFlags"] = new[] { "--json", "--yes" },
+        };
+    }
 
     // The frontend builder is pinned by digest, not floated on :latest, so a
     // repointed or compromised tag cannot reach a user's source tree (mounted at

--- a/README.md
+++ b/README.md
@@ -102,7 +102,25 @@ dev help
 
 ### Custom Commands
 
-If a `commands.json` file exists in the current directory, it defines the available commands. Each entry can either reference a built-in command or specify processes to run on Windows and non-Windows systems. A command can be marked as the default using `"default": true`.
+If a `commands.json` file exists in the current directory, it defines the available commands. Each entry can either reference a built-in command or specify processes to run on Windows and non-Windows systems. A command can be marked as the default using `"Default": true`.
+
+The keys are case-sensitive and use PascalCase: `Name`, `Description`, `Default`, `BuiltIn`, `Windows`, `NonWindows`.
+
+```json
+[
+  {
+    "Name": "build",
+    "BuiltIn": "build"
+  },
+  {
+    "Name": "deploy",
+    "Description": "Publish the solution",
+    "Windows": "dotnet publish {sln} -c Release",
+    "NonWindows": "dotnet publish {sln} -c Release",
+    "Default": true
+  }
+]
+```
 
 Placeholders `{sln}`, `{project}` and `{dir}` in the command lines are replaced with the detected solution file, project file and current directory. For safety, a command is refused (it does not run) when one of these placeholders resolves to a path containing a shell metacharacter (`& | ; < > \` $ " ' %`, or a line break), so a maliciously named file or directory cannot inject commands.
 

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -17,12 +17,17 @@ Domain terminology for **HC.Dev** (`dev`), a .NET global CLI tool that orchestra
 | Term | Definition | Aliases to avoid |
 | ---- | ---------- | ---------------- |
 | **Command** | A named unit of work the tool can execute (e.g. `build`, `bump`, `launch`). | Action, task, operation |
-| **Built-in Command** | A **Command** implemented in `Program.cs`: `launch`, `bump`, `bump-commit`, `build`, `frontend`, `clean`, `help`. | Default command, native command |
+| **Built-in Command** | A **Command** whose canonical facts (name, **Aliases**, description, **Needs Workspace**, default-ness, **Arg Syntax**) are declared as a `BuiltinCommand` record in the **Command Catalog**: `launch`, `bump`, `bump-commit`, `build`, `frontend`, `clean`, `help`. Its dispatch arm lives in `Program.cs`, kept in sync with the catalog by an exhaustiveness (drift) guard. | Default command, native command |
 | **Custom Command** | A **Command** defined in a **Commands Config** that invokes a shell command line instead of a **Built-in**. | Script command, shell command |
 | **Alias** | A short synonym for a **Built-in Command** (`b`, `c`, `h`/`?`, `f`, `v`, `vc`). | Shortcut, abbreviation |
 | **Default Command** | The **Command** executed when `dev` is called with no arguments; either the config entry marked `"default": true` or `launch` when no **Commands Config** exists. | Fallback command |
 | **Placeholder** | A token (`{sln}`, `{project}`, `{dir}`) inside a **Custom Command** line that is substituted with a detected path at **Run** time. | Variable, macro |
-| **Command Catalog** | The single source of truth (`CommandCatalog.cs`) for the **Built-in Command** names and the **Alias** map; consumed by both alias resolution and the **Suggestion** logic so the two cannot drift. | Command registry, command table |
+| **Command Catalog** | The single source of truth (`CommandCatalog.cs`) for the **Built-in Command** vocabulary: each builtin's canonical facts (name, **Aliases**, description, **Needs Workspace**, default-ness, **Arg Syntax**), the derived **Alias** map, **Command** resolution, the **Unknown Command** **Suggestion** candidate set, and the render-ready **Help Model** — including the **Built-in**↔**Commands Config** merge policy. Pure (no I/O) and exhaustively testable, so no consumer re-encodes any of it. | Command registry, command table |
+| **Needs Workspace** | Whether a **Built-in Command** requires a detected **Workspace** before it can run: `launch`, `bump`, `bump-commit`, and `build` do; `frontend`, `clean`, and `help` do not. A **Command** that needs a **Workspace** but finds none produces a failed **Step** with `Code: no_project_found` (exit 2). | Requires project, needs solution |
+| **Arg Syntax** | The argument-usage hint shown beside a **Command** in help (e.g. `[major\|minor\|patch\|revision]` for `bump`); display-only — the actual **Bump Part** is parsed from the **Run**'s arguments, not from this string. | Usage, args |
+| **Help Model** | The complete, ordered, render-ready list of **Help Rows** for the active **Commands Config** (or the **Built-in** set when none exists), produced by `CommandCatalog.HelpModel`. The single representation both the `--json` help payload and the human help table render, so the two cannot drift; the `help` row is always last. | Help data, help list |
+| **Help Row** | One entry in a **Help Model**: a **Command**'s name, **Aliases**, description, default-ness, **Help Source**, backing **Built-in** name (if any), and **Arg Syntax**. | Help entry, help line |
+| **Help Source** | Where a **Help Row** originates: `builtin` (a **Built-in Command**, including a **Commands Config** entry that backs a builtin via its `BuiltIn` field) or `config` (a **Custom Command** with its own shell line). Surfaced as each command's `source` field in the help **Envelope**. | Origin, kind |
 | **Unknown Command** | A typed token that matches no **Command** valid in the current context; produces a failed **Step** with `Code: unknown_command` and, when a near match exists, a **Suggestion**. | Bad command, invalid command |
 | **Suggestion** | The display-only nearest **Command** offered for an **Unknown Command** ("Did you mean `b` (build)?"), computed by case-insensitive edit distance over a context-dependent candidate set. Printed as a console hint and surfaced in the **Step** error's `suggestion` field; **never executed automatically and never prompts**. | Did-you-mean, autocorrect |
 
@@ -30,6 +35,7 @@ Domain terminology for **HC.Dev** (`dev`), a .NET global CLI tool that orchestra
 
 | Term | Definition | Aliases to avoid |
 | ---- | ---------- | ---------------- |
+| **Workspace** | The build/version context detected for a **Run**: the **Solution** if present, otherwise a bare **Project**; `null` when neither is found. Owns `.sln`/`.slnx` precedence, the `src/` fallback, submodule detection, **Dev Config** parent-directory inheritance, and ignore-list filtering; yields the **Build Target** (what the **Builder** compiles or the **Launcher** opens) and the **Bump Targets**. | Project context, target |
 | **Solution** | A `.sln` or `.slnx` file detected in the **Working Directory** (or its `src/` subfolder); enumerates **Projects** for bulk operations. | Sln, workspace |
 | **Project** | A `.csproj` file, either standalone or enumerated from a **Solution**; the unit whose `<Version>` is read and rewritten. | Module, assembly |
 | **Project Candidate** | A **Project** discovered in a **Solution** together with an inclusion decision and, if excluded, a **Skip Reason** (`submodule`, `ignored`). | Project entry |
@@ -84,6 +90,8 @@ Domain terminology for **HC.Dev** (`dev`), a .NET global CLI tool that orchestra
 - A **Custom Command** resolves **Placeholders** using the **Solution**, **Project**, and **Working Directory** detected for the **Run**.
 - A **Bump Commit** is a **Bump** plus a git commit and tag; it aborts committing when zero or more-than-one distinct new **SemVer** values were produced across **Projects**.
 - A **Scaffold** produces zero or more **Mutations** and runs before the **Frontend Builder**; if a required file is missing and neither **Auto-Yes** nor an interactive **Trust Prompt**-style confirmation approves creation, the `frontend` **Step** fails as `interaction_required`.
+- A **Run** discovers at most one **Workspace**, wrapping the detected **Solution** and/or **Project** and exposing the **Build Target** and the **Bump Targets**; a **Built-in Command** that **Needs Workspace** fails its **Step** with `no_project_found` (exit 2) when none is found.
+- A **Help Model** holds one **Help Row** per visible **Command**, ordered with the `help` row last; both the human help table and the `--json` help payload render from it and nothing else, and each **Help Row** carries its **Help Source** (`builtin` or `config`).
 
 ## Example dialogue
 
@@ -106,6 +114,14 @@ Domain terminology for **HC.Dev** (`dev`), a .NET global CLI tool that orchestra
 > **Dev:** "Last thing — what does `dev frontend --json` report when it has to create `build-frontend.sh`?"
 >
 > **Domain expert:** "The **Scaffold** runs first and records a **Mutation** (`created`) for that file, plus a `crlf_to_lf` or `appended` **Mutation** if it touches `.gitattributes`. You'll see them in the **Envelope**'s `mutations` list. But under **JSON Mode** without **Auto-Yes**, a *missing* **Frontend Build Script** can't be created non-interactively, so the **Step** fails with `interaction_required` instead."
+>
+> **Dev:** "Why does `dev clean` work in an empty folder but `dev build` says `no_project_found`?"
+>
+> **Domain expert:** "Because `build` **Needs Workspace** and `clean` doesn't. Each **Built-in Command** declares that as a fact in the **Command Catalog**: `launch`, `bump`, `bump-commit`, and `build` require a detected **Workspace**; `frontend`, `clean`, and `help` run without one. No **Workspace** plus a command that needs one is a failed **Step** with `no_project_found`, exit 2."
+>
+> **Dev:** "And `dev help --json` — where does that command list come from?"
+>
+> **Domain expert:** "The **Command Catalog** builds one **Help Model**: an ordered list of **Help Rows**, the `help` row last. Both the human table and the `--json` payload render that same list, so they can't drift. Each **Help Row** carries a **Help Source** — `builtin`, or `config` for a **Custom Command** — and a renamed config entry that points at a **Built-in** still reports `source: builtin` with its backing name."
 
 ## Flagged ambiguities
 
@@ -116,3 +132,5 @@ Domain terminology for **HC.Dev** (`dev`), a .NET global CLI tool that orchestra
 - **"Target".** Three meanings collide. (1) `BuildTarget` (in `Workspace.cs`) is the "**Solution** file if present, else **Project** file" the **Builder** compiles or the **Launcher** opens. (2) `BumpTarget` (also `Workspace.cs`) is a **Project** enumerated for a **Bump**, carrying its `Include` flag and **Skip Reason** — this is the "**Project Candidate**" domain term above. (3) The JSON field in `Step.Data` is `"target"` (the **Build Target** path) and stays so for wire stability. Recommendation: never say bare "target" in code review — say **Build Target** (what to compile/open) or **Bump Target** (a **Project** to version); both are deliberately distinct from MSBuild's *target*.
 - **"Config".** `commands.json` (**Commands Config**) and `dev.json` (**Dev Config**) are distinct files with different schemas and lookup rules (parent-directory fallback applies only to **Dev Config**). Always qualify which one.
 - **"Default".** A **Commands Config Entry** may be marked `default: true` (**Default Command**), which is different from the implicit fallback to `launch` when no **Commands Config** exists. Recommendation: use **Default Command** only for the explicit config flag; call the no-config behavior the **Implicit Launch Fallback**.
+- **"Built-in" (three referents).** (1) a **Built-in Command** — the CLI verb. (2) the `BuiltinCommand` record in the **Command Catalog** — the *canonical facts* of a builtin. (3) the `BuiltIn` field on a **Commands Config Entry** / **Help Row** — the *name of* the **Built-in Command** that a renamed config entry re-exposes. Recommendation: say **Built-in Command** for the verb, **BuiltinCommand record** for the type, and **backing built-in** for the field's referent.
+- **"Workspace".** As a loose synonym for **Solution** it is still an alias to avoid (see **Solution**). But **Workspace** (the value object in `Workspace.cs`) is now a distinct domain term: the detected **Solution**-or-**Project** *context* for a **Run**, which a **Built-in Command** may require via **Needs Workspace**. Recommendation: say **Workspace** only for the context, never for the `.sln` file alone.

--- a/tests/Dev.Tests/CommandCatalogHelpModelTests.cs
+++ b/tests/Dev.Tests/CommandCatalogHelpModelTests.cs
@@ -1,0 +1,278 @@
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Dev.Tests;
+
+// Boundary tests for the CommandCatalog surface introduced by issue #24:
+// HelpModel (no-config + config forks), SuggestionCandidates, the dispatch
+// exhaustiveness drift guard, and the NeedsWorkspace partition.
+public sealed class CommandCatalogHelpModelTests
+{
+    private static HelpRow Row(IReadOnlyList<HelpRow> rows, string name) =>
+        rows.Single(r => r.Name == name);
+
+    // ---- 1. HelpModel(null) — no-config ----------------------------------
+
+    [Fact]
+    public void HelpModel_noConfig_returns_seven_rows_in_canonical_order()
+    {
+        var rows = CommandCatalog.HelpModel(null);
+        Assert.Equal(
+            new[] { "launch", "bump", "bump-commit", "build", "frontend", "clean", "help" },
+            rows.Select(r => r.Name));
+    }
+
+    [Fact]
+    public void HelpModel_noConfig_isDefault_true_only_for_launch_and_null_for_help()
+    {
+        var rows = CommandCatalog.HelpModel(null);
+
+        Assert.True(Row(rows, "launch").IsDefault);
+        Assert.False(Row(rows, "bump").IsDefault);
+        Assert.False(Row(rows, "bump-commit").IsDefault);
+        Assert.False(Row(rows, "build").IsDefault);
+        Assert.False(Row(rows, "frontend").IsDefault);
+        Assert.False(Row(rows, "clean").IsDefault);
+
+        // The discriminator the JSON mapper keys off: help's IsDefault is NULL,
+        // not false. Assert it explicitly.
+        Assert.Null(Row(rows, "help").IsDefault);
+    }
+
+    [Fact]
+    public void HelpModel_noConfig_argSyntax_only_on_bump_commands()
+    {
+        var rows = CommandCatalog.HelpModel(null);
+
+        Assert.Equal("[major|minor|patch|revision]", Row(rows, "bump").ArgSyntax);
+        Assert.Equal("[major|minor|patch|revision]", Row(rows, "bump-commit").ArgSyntax);
+
+        Assert.Null(Row(rows, "launch").ArgSyntax);
+        Assert.Null(Row(rows, "build").ArgSyntax);
+        Assert.Null(Row(rows, "frontend").ArgSyntax);
+        Assert.Null(Row(rows, "clean").ArgSyntax);
+        Assert.Null(Row(rows, "help").ArgSyntax);
+    }
+
+    [Fact]
+    public void HelpModel_noConfig_every_row_is_builtin_source_with_null_builtIn()
+    {
+        var rows = CommandCatalog.HelpModel(null);
+        Assert.All(rows, r =>
+        {
+            Assert.Equal("builtin", r.Source);
+            Assert.Null(r.BuiltIn);
+        });
+    }
+
+    [Fact]
+    public void HelpModel_noConfig_aliases_match_the_catalog()
+    {
+        var rows = CommandCatalog.HelpModel(null);
+
+        Assert.Empty(Row(rows, "launch").Aliases);
+        Assert.Equal(new[] { "v" }, Row(rows, "bump").Aliases);
+        Assert.Equal(new[] { "vc" }, Row(rows, "bump-commit").Aliases);
+        Assert.Equal(new[] { "b" }, Row(rows, "build").Aliases);
+        Assert.Equal(new[] { "f" }, Row(rows, "frontend").Aliases);
+        Assert.Equal(new[] { "c" }, Row(rows, "clean").Aliases);
+        Assert.Equal(new[] { "h", "?" }, Row(rows, "help").Aliases);
+    }
+
+    [Fact]
+    public void HelpModel_noConfig_descriptions_match_the_builtin_records()
+    {
+        var rows = CommandCatalog.HelpModel(null);
+
+        Assert.Equal("Displays this help message.", Row(rows, "help").Description);
+        Assert.Equal("Builds the current solution or project in Release mode.", Row(rows, "build").Description);
+    }
+
+    // ---- 2. HelpModel(config) — with commands.json -----------------------
+
+    private static List<CommandsConfigEntry> GoldenConfig() => new()
+    {
+        new CommandsConfigEntry
+        {
+            Name = "deploy",
+            Description = "Deploy the current app",
+            Windows = "deploy.cmd {sln}",
+            NonWindows = "./deploy.sh {sln}",
+            Default = true,
+        },
+        new CommandsConfigEntry { Name = "build", BuiltIn = "build" },
+        new CommandsConfigEntry { Name = "vbump", BuiltIn = "bump" },
+    };
+
+    [Fact]
+    public void HelpModel_config_returns_four_rows_in_order()
+    {
+        var rows = CommandCatalog.HelpModel(GoldenConfig());
+        Assert.Equal(new[] { "deploy", "build", "vbump", "help" }, rows.Select(r => r.Name));
+    }
+
+    [Fact]
+    public void HelpModel_config_custom_deploy_row()
+    {
+        var deploy = Row(CommandCatalog.HelpModel(GoldenConfig()), "deploy");
+
+        Assert.Equal("config", deploy.Source);
+        Assert.Null(deploy.BuiltIn);
+        Assert.Empty(deploy.Aliases);
+        Assert.Equal("Deploy the current app", deploy.Description);
+        Assert.True(deploy.IsDefault);
+        Assert.Null(deploy.ArgSyntax);
+    }
+
+    [Fact]
+    public void HelpModel_config_builtin_backed_build_row()
+    {
+        var build = Row(CommandCatalog.HelpModel(GoldenConfig()), "build");
+        var backing = CommandCatalog.Find("build")!;
+
+        Assert.Equal("builtin", build.Source);
+        Assert.Equal("build", build.BuiltIn);
+        Assert.Equal(new[] { "b" }, build.Aliases);
+        Assert.Equal(backing.Description, build.Description);
+        Assert.False(build.IsDefault);
+    }
+
+    [Fact]
+    public void HelpModel_config_builtin_backed_renamed_vbump_row()
+    {
+        var vbump = Row(CommandCatalog.HelpModel(GoldenConfig()), "vbump");
+        var backing = CommandCatalog.Find("bump")!;
+
+        Assert.Equal("vbump", vbump.Name);
+        Assert.Equal("builtin", vbump.Source);
+        Assert.Equal("bump", vbump.BuiltIn);
+        Assert.Equal(new[] { "v" }, vbump.Aliases);
+        Assert.Equal(backing.Description, vbump.Description);
+        Assert.False(vbump.IsDefault);
+    }
+
+    [Fact]
+    public void HelpModel_config_synthetic_help_row_is_appended()
+    {
+        var help = Row(CommandCatalog.HelpModel(GoldenConfig()), "help");
+
+        Assert.Equal("help", help.Name);
+        Assert.Equal(new[] { "h", "?" }, help.Aliases);
+        Assert.Null(help.IsDefault);
+        Assert.Equal("builtin", help.Source);
+        Assert.Null(help.BuiltIn);
+    }
+
+    [Theory]
+    [InlineData("help")]
+    [InlineData("h")]
+    public void HelpModel_config_entry_named_help_or_h_is_skipped_and_synthetic_help_appended_once(string name)
+    {
+        var config = new List<CommandsConfigEntry>
+        {
+            new CommandsConfigEntry { Name = "deploy", Description = "Deploy the current app", Default = true },
+            new CommandsConfigEntry { Name = name, Description = "should be skipped" },
+        };
+
+        var rows = CommandCatalog.HelpModel(config);
+
+        // Exactly one help row, and it is the synthetic builtin one (not the
+        // skipped config entry's description).
+        var helpRows = rows.Where(r => r.Name == "help").ToList();
+        Assert.Single(helpRows);
+        Assert.Equal("Displays this help message.", helpRows[0].Description);
+        Assert.Equal("builtin", helpRows[0].Source);
+        // Custom row named "h" must not survive either.
+        Assert.DoesNotContain(rows, r => r.Name == "h");
+        Assert.Equal(new[] { "deploy", "help" }, rows.Select(r => r.Name));
+    }
+
+    [Fact]
+    public void HelpModel_config_custom_description_falls_back_to_os_command()
+    {
+        var config = new List<CommandsConfigEntry>
+        {
+            new CommandsConfigEntry
+            {
+                Name = "deploy",
+                Description = null,
+                Windows = "deploy.cmd {sln}",
+                NonWindows = "./deploy.sh {sln}",
+            },
+        };
+
+        var deploy = Row(CommandCatalog.HelpModel(config), "deploy");
+        var expected = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "deploy.cmd {sln}"
+            : "./deploy.sh {sln}";
+        Assert.Equal(expected, deploy.Description);
+    }
+
+    [Fact]
+    public void HelpModel_config_custom_description_all_null_yields_empty_string()
+    {
+        var config = new List<CommandsConfigEntry>
+        {
+            new CommandsConfigEntry { Name = "deploy", Description = null, Windows = null, NonWindows = null },
+        };
+
+        var deploy = Row(CommandCatalog.HelpModel(config), "deploy");
+        Assert.Equal("", deploy.Description);
+    }
+
+    // ---- 3. SuggestionCandidates -----------------------------------------
+
+    [Fact]
+    public void SuggestionCandidates_null_is_builtin_names_plus_alias_keys()
+    {
+        var candidates = CommandCatalog.SuggestionCandidates(null).ToList();
+
+        foreach (var name in new[] { "launch", "bump", "bump-commit", "build", "frontend", "clean", "help" })
+            Assert.Contains(name, candidates);
+
+        foreach (var aliasKey in new[] { "b", "c", "h", "?", "f", "v", "vc" })
+            Assert.Contains(aliasKey, candidates);
+    }
+
+    [Fact]
+    public void SuggestionCandidates_config_is_config_names_in_order()
+    {
+        var candidates = CommandCatalog.SuggestionCandidates(GoldenConfig()).ToList();
+        Assert.Equal(new[] { "deploy", "build", "vbump" }, candidates);
+    }
+
+    // ---- 4. Dispatch exhaustiveness (drift guard) ------------------------
+
+    [Fact]
+    public void DispatchableCommands_is_set_equal_to_builtin_names()
+    {
+        var dispatch = Program.DispatchableCommands;
+        var builtins = CommandCatalog.Builtins.Select(b => b.Name).ToHashSet();
+
+        // No dispatch arm without a builtin, and no builtin without a dispatch arm.
+        Assert.True(dispatch.SetEquals(builtins),
+            $"dispatch-only: [{string.Join(",", dispatch.Except(builtins))}]; " +
+            $"builtin-only: [{string.Join(",", builtins.Except(dispatch))}]");
+    }
+
+    // ---- 5. NeedsWorkspace partition -------------------------------------
+
+    [Theory]
+    [InlineData("launch")]
+    [InlineData("bump")]
+    [InlineData("bump-commit")]
+    [InlineData("build")]
+    public void Builtin_needs_workspace(string name)
+    {
+        Assert.True(CommandCatalog.Find(name)!.NeedsWorkspace);
+    }
+
+    [Theory]
+    [InlineData("frontend")]
+    [InlineData("clean")]
+    [InlineData("help")]
+    public void Builtin_does_not_need_workspace(string name)
+    {
+        Assert.False(CommandCatalog.Find(name)!.NeedsWorkspace);
+    }
+}

--- a/tests/Dev.Tests/CommandCatalogTests.cs
+++ b/tests/Dev.Tests/CommandCatalogTests.cs
@@ -6,7 +6,7 @@ public sealed class CommandCatalogSuggestTests
 {
     // Mirrors the production caller: builtins plus alias keys.
     private static IEnumerable<string> BuiltinsAndAliases() =>
-        CommandCatalog.Builtins.Concat(CommandCatalog.Aliases.Keys);
+        CommandCatalog.Builtins.Select(c => c.Name).Concat(CommandCatalog.Aliases.Keys);
 
     [Fact]
     public void Bb_suggests_b_the_real_world_bug_case()
@@ -85,7 +85,7 @@ public sealed class CommandCatalogSuggestTests
     {
         // distance 0; 0 <= 2 and 0 < 5 -> returns "build". (Won't occur in
         // practice since known commands never reach Suggest, but pin behavior.)
-        Assert.Equal("build", CommandCatalog.Suggest("build", CommandCatalog.Builtins));
+        Assert.Equal("build", CommandCatalog.Suggest("build", CommandCatalog.Builtins.Select(c => c.Name)));
     }
 }
 

--- a/tests/Dev.Tests/HelpContractTests.cs
+++ b/tests/Dev.Tests/HelpContractTests.cs
@@ -1,0 +1,194 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Dev.Tests;
+
+// Golden --json help contract. The fragile invariants are KEY PRESENCE/ABSENCE
+// and null-vs-absent, so we serialize the real BuildHelpData with the real
+// JsonOptions and assert structurally with JsonDocument — never byte-comparing
+// against the (Python-formatted) scratchpad fixtures.
+public sealed class HelpContractTests
+{
+    private static JsonDocument Serialize(List<CommandsConfigEntry>? config)
+    {
+        var json = JsonSerializer.Serialize(Program.BuildHelpData(config), Program.JsonOptions);
+        return JsonDocument.Parse(json);
+    }
+
+    private static bool Has(JsonElement obj, string prop) => obj.TryGetProperty(prop, out _);
+
+    private static string[] Names(JsonElement commands) =>
+        commands.EnumerateArray().Select(c => c.GetProperty("name").GetString()!).ToArray();
+
+    private static JsonElement Command(JsonElement commands, string name) =>
+        commands.EnumerateArray().Single(c => c.GetProperty("name").GetString() == name);
+
+    private static string[] Aliases(JsonElement command) =>
+        command.GetProperty("aliases").EnumerateArray().Select(a => a.GetString()!).ToArray();
+
+    // ---- BuildHelpData(null) ---------------------------------------------
+
+    [Fact]
+    public void NoConfig_commands_is_seven_objects_in_order()
+    {
+        using var doc = Serialize(null);
+        var commands = doc.RootElement.GetProperty("commands");
+
+        Assert.Equal(JsonValueKind.Array, commands.ValueKind);
+        Assert.Equal(7, commands.GetArrayLength());
+        Assert.Equal(
+            new[] { "launch", "bump", "bump-commit", "build", "frontend", "clean", "help" },
+            Names(commands));
+    }
+
+    [Fact]
+    public void NoConfig_launch_through_clean_have_default_bool_and_no_builtIn()
+    {
+        using var doc = Serialize(null);
+        var commands = doc.RootElement.GetProperty("commands");
+
+        foreach (var name in new[] { "launch", "bump", "bump-commit", "build", "frontend", "clean" })
+        {
+            var cmd = Command(commands, name);
+            Assert.True(Has(cmd, "default"), $"{name} should have a default property");
+            Assert.Contains(cmd.GetProperty("default").ValueKind, new[] { JsonValueKind.True, JsonValueKind.False });
+            Assert.False(Has(cmd, "builtIn"), $"{name} should NOT have a builtIn property");
+            Assert.Equal("builtin", cmd.GetProperty("source").GetString());
+        }
+    }
+
+    [Fact]
+    public void NoConfig_launch_default_is_true_others_false()
+    {
+        using var doc = Serialize(null);
+        var commands = doc.RootElement.GetProperty("commands");
+
+        Assert.True(Command(commands, "launch").GetProperty("default").GetBoolean());
+        foreach (var name in new[] { "bump", "bump-commit", "build", "frontend", "clean" })
+            Assert.False(Command(commands, name).GetProperty("default").GetBoolean());
+    }
+
+    [Fact]
+    public void NoConfig_help_row_has_no_default_and_no_builtIn()
+    {
+        using var doc = Serialize(null);
+        var help = Command(doc.RootElement.GetProperty("commands"), "help");
+
+        Assert.False(Has(help, "default"));
+        Assert.False(Has(help, "builtIn"));
+        Assert.Equal("builtin", help.GetProperty("source").GetString());
+    }
+
+    [Fact]
+    public void NoConfig_aliases_are_correct()
+    {
+        using var doc = Serialize(null);
+        var commands = doc.RootElement.GetProperty("commands");
+
+        Assert.Empty(Aliases(Command(commands, "launch")));
+        Assert.Equal(new[] { "v" }, Aliases(Command(commands, "bump")));
+        Assert.Equal(new[] { "vc" }, Aliases(Command(commands, "bump-commit")));
+        Assert.Equal(new[] { "b" }, Aliases(Command(commands, "build")));
+        Assert.Equal(new[] { "f" }, Aliases(Command(commands, "frontend")));
+        Assert.Equal(new[] { "c" }, Aliases(Command(commands, "clean")));
+        Assert.Equal(new[] { "h", "?" }, Aliases(Command(commands, "help")));
+    }
+
+    [Fact]
+    public void NoConfig_chaining_placeholders_and_globalFlags()
+    {
+        using var doc = Serialize(null);
+        var root = doc.RootElement;
+
+        var chaining = root.GetProperty("chaining");
+        Assert.Equal("+", chaining.GetProperty("separator").GetString());
+        Assert.Equal("dev b+f", chaining.GetProperty("example").GetString());
+
+        Assert.Equal(
+            new[] { "{sln}", "{project}", "{dir}" },
+            root.GetProperty("placeholders").EnumerateArray().Select(e => e.GetString()).ToArray());
+
+        Assert.Equal(
+            new[] { "--json", "--yes" },
+            root.GetProperty("globalFlags").EnumerateArray().Select(e => e.GetString()).ToArray());
+    }
+
+    // ---- BuildHelpData(config) -------------------------------------------
+
+    private static List<CommandsConfigEntry> GoldenConfig() => new()
+    {
+        new CommandsConfigEntry
+        {
+            Name = "deploy",
+            Description = "Deploy the current app",
+            Windows = "deploy.cmd {sln}",
+            NonWindows = "./deploy.sh {sln}",
+            Default = true,
+        },
+        new CommandsConfigEntry { Name = "build", BuiltIn = "build" },
+        new CommandsConfigEntry { Name = "vbump", BuiltIn = "bump" },
+    };
+
+    [Fact]
+    public void Config_commands_is_four_objects_in_order()
+    {
+        using var doc = Serialize(GoldenConfig());
+        var commands = doc.RootElement.GetProperty("commands");
+
+        Assert.Equal(4, commands.GetArrayLength());
+        Assert.Equal(new[] { "deploy", "build", "vbump", "help" }, Names(commands));
+    }
+
+    [Fact]
+    public void Config_deploy_emits_builtIn_as_json_null_and_default_true()
+    {
+        using var doc = Serialize(GoldenConfig());
+        var deploy = Command(doc.RootElement.GetProperty("commands"), "deploy");
+
+        Assert.Equal("config", deploy.GetProperty("source").GetString());
+        // Contract subtlety: custom config rows emit "builtIn": null, NOT omitted.
+        Assert.True(Has(deploy, "builtIn"));
+        Assert.Equal(JsonValueKind.Null, deploy.GetProperty("builtIn").ValueKind);
+        Assert.True(deploy.GetProperty("default").GetBoolean());
+    }
+
+    [Fact]
+    public void Config_build_is_builtin_backed()
+    {
+        using var doc = Serialize(GoldenConfig());
+        var build = Command(doc.RootElement.GetProperty("commands"), "build");
+
+        Assert.Equal("builtin", build.GetProperty("source").GetString());
+        Assert.Equal("build", build.GetProperty("builtIn").GetString());
+        Assert.Equal(new[] { "b" }, Aliases(build));
+    }
+
+    [Fact]
+    public void Config_vbump_is_builtin_backed_by_bump()
+    {
+        using var doc = Serialize(GoldenConfig());
+        var vbump = Command(doc.RootElement.GetProperty("commands"), "vbump");
+
+        Assert.Equal("builtin", vbump.GetProperty("source").GetString());
+        Assert.Equal("bump", vbump.GetProperty("builtIn").GetString());
+        Assert.Equal(new[] { "v" }, Aliases(vbump));
+    }
+
+    [Fact]
+    public void Config_help_row_has_no_default_and_no_builtIn()
+    {
+        using var doc = Serialize(GoldenConfig());
+        var help = Command(doc.RootElement.GetProperty("commands"), "help");
+
+        Assert.False(Has(help, "default"));
+        Assert.False(Has(help, "builtIn"));
+    }
+
+    [Fact]
+    public void Config_command_order_is_exactly_deploy_build_vbump_help()
+    {
+        using var doc = Serialize(GoldenConfig());
+        var order = Names(doc.RootElement.GetProperty("commands"));
+        Assert.Equal(new[] { "deploy", "build", "vbump", "help" }, order);
+    }
+}


### PR DESCRIPTION
Implements #24 (the hardened RFC from `/improve-codebase-architecture`).

## What

"What commands exist" was duplicated across **four** sites with no single source of truth — `CommandCatalog.Aliases`/`Builtins`, the dispatch `switch` (needs-workspace encoded *implicitly* by position relative to the workspace-null guard), `BuildHelpData` (its own inverted alias dict + re-listed names), and `RenderHelpTable` (hardcoded rows + a separate `BuiltinDescription` switch). Adding or renaming a command meant editing all of them, and the two help renderers could silently drift.

This deepens `CommandCatalog` into the single source of builtin truth:

- One `static readonly` `BuiltinCommand` literal (name, aliases, description, `NeedsWorkspace`, `IsDefault`, `ArgSyntax`).
- `Aliases`, `Find`, `SuggestionCandidates`, and a render-ready `HelpModel` are all **derived** from it.
- Both the `--json` payload and the human table consume `HelpModel` and nothing else; the builtin↔config merge, OS description fallback, alias inversion, and help-row synthesis live there once.
- `Program.ExecuteCommand` becomes a flat `NeedsWorkspace`-guarded `switch` on the canonical name. `BuiltinDescription`, the inverted alias dict, and the re-listed name arrays are deleted.
- `BuildHelpData` + the `JsonSerializerOptions` move onto `partial class Program` (`internal static`) so the `--json` contract is unit-testable; `DispatchableCommands` pins switch↔catalog drift via an exhaustiveness test.

## Design decisions (chosen variant: metadata-only catalog + guarded switch)

Handlers stay in `Program` — the catalog is pure and has no reference to the impure command layer (clean dependency direction, clean stack traces). Rejected during design: a name→handler dictionary, a `Bind()`/assign-once registry, an `ICommandSource` plugin seam (all speculative for a 7-command CLI).

## Behavior

Preserved byte-for-byte for `--json help` (no-config **and** with-config, including the `"builtIn": null`-present-not-omitted subtlety that `WhenWritingNull` does *not* drop for dictionary values) and all exit/error codes. **One intentional improvement:** a `commands.json` entry with `"builtIn": "help"` now renders help (exit 0) instead of failing — `help` is a documented builtin, and the old failure was a latent bug; no test pinned it.

## Tests

37 new tests (`CommandCatalogHelpModelTests`, `HelpContractTests`) covering `HelpModel(null)`/`(config)`, `SuggestionCandidates`, the dispatch exhaustiveness guard, the `NeedsWorkspace` partition, and the golden `--json` contract (asserted structurally — key presence/absence + null-vs-absent). The 12 original `CommandCatalog` tests are unchanged save two mechanical `.Select(c => c.Name)` call sites (the `Builtins` element type changed `string` → `BuiltinCommand`).

**Suite: 184/184 green. Build: 0 warnings / 0 errors.** No STRIDE.md change (no new trust boundary, process, file, or input surface).

## Pipeline

Built via `/implement-issue`: implement → test → independent code-review + spec-conformance audit (both passed; verifier 28/28 OK, reviewer 0 blocking). The two reviewer comment-accuracy nits are fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)